### PR TITLE
Fix theme display by adding required plugs and environment

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,25 @@ layout:
   /usr/share/locale:
     bind: $SNAP/usr/share/locale
 
+plugs:
+  gtk-2-engines:
+    interface: content
+    target: $SNAP/lib/gtk-2.0
+    default-provider: gtk2-common-themes
+  gtk-2-themes:
+    interface: content
+    target: $SNAP/share/themes
+    default-provider: gtk2-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/share/icons
+    default-provider: gtk-common-themes
+
+environment:
+  GTK_PATH: $SNAP/lib/gtk-2.0
+  GTK_DATA_PREFIX: $SNAP
+  XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
+
 apps:
   audacity:
     command: desktop-launch $SNAP/usr/bin/audacity


### PR DESCRIPTION
The current snap installed from the store results in crufty theming:

![Screenshot from 2019-05-21 10-29-54](https://user-images.githubusercontent.com/56540/58061107-dab26e80-7bb3-11e9-8130-606eeeb121f0.png)

Adding the plugs and environment sections results in the correct theme being used:

![Screenshot from 2019-05-21 10-30-20](https://user-images.githubusercontent.com/56540/58061123-f0279880-7bb3-11e9-8ebe-db38e8b6f59e.png)
