### PR TITLE
Update stage-package to t64 version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
     build-packages:
       - libasound2-dev
     stage-packages:
-      - libasound2
+      - libasound2t64
       - libasound2-plugins
       - yad
 


### PR DESCRIPTION
The current snap build fails locally with:

```bash
Failed to stage: parts list the same file with different contents or permissions.
Detailed information: Parts 'audacity' and 'alsa-mixin' list the following files, but with different contents or permissions:
    usr/lib/x86_64-linux-gnu/libasound.so.2
```

Indeed if you shell into the snap you can see the issue:

```bash
snapcraft-audacity-amd64-7078962 ../parts# ls -lh ./audacity/install/usr/lib/x86_64-linux-gnu/libasound.so.2
lrwxrwxrwx 1 root root 18 Mar 30  2024 ./audacity/install/usr/lib/x86_64-linux-gnu/libasound.so.2 -> libasound.so.2.0.0
snapcraft-audacity-amd64-7078962 ../parts# ls -lh ./alsa-mixin/install/usr/lib/x86_64-linux-gnu/libasound.so.2
lrwxrwxrwx 1 root root 18 Feb 11  2015 ./alsa-mixin/install/usr/lib/x86_64-linux-gnu/libasound.so.2 -> liboss4-salsa.so.2
```

After some poking around I discovered that `libasound2` is now replaced by `libasound2t64` in the archive, and this library is needed as it points the sym link to the appropriate location (consistent with the `audacity` part).

```bash
$ apt info libasound2t64
Package: libasound2t64
Version: 1.2.11-1build2
Priority: optional
Section: libs
Source: alsa-lib
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Debian ALSA Maintainers <pkg-alsa-devel@lists.alioth.debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 1,198 kB
Provides: libasound2 (= 1.2.11-1build2)
Depends: libasound2-data (>= 1.2.11-1build2), libc6 (>= 2.38)
Suggests: libasound2-plugins (>= 1.0.24)
Breaks: alsa-utils (<< 1.2.1), libasound2 (<< 1.2.11-1build2)
Replaces: libasound2
Homepage: https://www.alsa-project.org/
Task: ubuntu-desktop-minimal, ubuntu-desktop, ubuntu-desktop-raspi, kubuntu-desktop, xubuntu-minimal, xubuntu-desktop, lubuntu-desktop, ubuntustudio-desktop-core, ubuntustudio-desktop, ubuntukylin-desktop, ubuntukylin-desktop-minimal, ubuntu-mate-core, ubuntu-mate-desktop, ubuntu-budgie-desktop-minimal, ubuntu-budgie-desktop, ubuntu-budgie-desktop-raspi, ubuntu-unity-desktop, edubuntu-desktop-gnome-minimal, edubuntu-desktop-gnome-raspi, ubuntucinnamon-desktop-minimal, ubuntucinnamon-desktop-raspi
Download-Size: 399 kB
APT-Manual-Installed: no
APT-Sources: http://us.archive.ubuntu.com/ubuntu noble/main amd64 Packages
Description: shared library for ALSA applications
 This package contains the ALSA library and its standard plugins, as well
 as the required configuration files.
 .
 ALSA is the Advanced Linux Sound Architecture.
```

After this change I can now build the snap locally.

