### PR TITLE
Fix startup issues

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
     build-packages:
       - libasound2-dev
     stage-packages:
-      - libasound2
+      - libasound2t64
       - libasound2-plugins
       - yad
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,9 @@ parts:
     override-pull: |
       craftctl default
       sed -i -E 's|Icon=.*|Icon=/usr/share/icons/hicolor/scalable/apps/audacity.svg|' src/audacity.desktop.in
-      sed -i -E 's|Exec=env UBUNTU_MENUPROXY=0 |Exec=|' src/audacity.desktop.in
+      sed -i -E 's|Exec=env GDK_BACKEND=x11 UBUNTU_MENUPROXY=0 |Exec=|' src/audacity.desktop.in
+      # mod-opus broken with "Error: inappropriate ioctl for device". This disables it.
+      sed -i '/mod-opus/d' libraries/lib-module-manager/ModuleSettings.cpp
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Note this PR contains an unmerged commit from https://github.com/diddlesnaps/audacity/pull/41, which is needed in order for the snap to build.

This PR fixes a few issues that occur at startup:

- Switch `mod-opus` module to disabled as it is currently failing and resulting in the following popup the first time a user launches audacity
![Screenshot from 2025-04-10 06-02-13](https://github.com/user-attachments/assets/0bed7eb5-7978-48f1-a716-72abfbf93365)
- Fix `sed` command based on [string in upstream source](https://github.com/audacity/audacity/blob/release-3.7.1/src/audacity.desktop.in#L64). Without this change a user sees the following popups when launching GIMP from the desktop (i.e. not the command line).
![Screenshot from 2025-04-10 06-38-57](https://github.com/user-attachments/assets/2a7a23bc-6785-4fcd-953e-6e9d151f0023)
![Screenshot from 2025-04-10 06-39-03](https://github.com/user-attachments/assets/31ad2071-e989-4e6d-9c3c-9e9eb4d72b3c)
![Screenshot from 2025-04-10 06-39-09](https://github.com/user-attachments/assets/942f0fee-43eb-44b9-8ad7-85147ab64187)


