### PR TITLE
feat: add OpenVINO AI Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,59 @@ distributions.</p>
 
 <p align="center">Published for <img src="https://raw.githubusercontent.com/anythingcodes/slack-emoji-for-techies/gh-pages/emoji/tux.png" align="top" width="24" /> with :gift_heart: by Snapcrafters</p>
 
+## OpenVINO™ AI Plugins
+
+This snap contains support for AI features including:
+
+  - Music Separation
+  - Noise Suppression
+  - Music Generation and Continuation
+  - Transcription
+  - Super Resolution
+
+The plugins come installed out-of-the-box and support running on Intel hardware only (CPU, GPU, and NPU). Instructions for using each of the features can be found in the [upstream GitHub repository](https://github.com/intel/openvino-plugins-ai-audacity/tree/main/doc/feature_doc).
+
+> [!IMPORTANT]
+> The models (which are roughly 6.2 GiB in size total) are NOT built into the snap. To use the AI features you must download and install them from the command line. Note that downloading the models may take several minutes or longer, depending on the speed of your internet connection. Please be patient!
+
+To ease the process of downloading and installing the models, an interactive command is available within the snap that can be invoked like so:
+
+```shell
+sudo audacity.fetch-models
+```
+
+This will provide you with an interactive menu where you can select the model you wish to download and install. Alternatively, if you wish to enable all of the AI features, you can simply pass the `--batch` flag:
+
+```shell
+sudo audacity.fetch-models --batch
+```
+
+
+> [!IMPORTANT]
+> Please ensure you are in the `render` Unix group on your system in order to access Intel accelerators for the plugins (Intel GPU and NPU).
+To check your current groups, please run the following from a terminal:
+
+```shell
+groups
+```
+
+If you do not see `render` listed in the output, you may add your current user with the following:
+
+```shell
+sudo usermod -a -G render $USER
+```
+
+Now log out and back in to ensure your active session has the `render` group included.
+
+To ensure the device nodes have appropriate group permissions set, you may also run:
+
+```shell
+sudo chown root:render /dev/accel/accel*
+sudo chmod g+rw /dev/accel/accel*
+sudo chown root:render /dev/dri/render*
+sudo chmod g+rw /dev/dri/render*
+```
+
 ## How to contribute to this snap
 
 Thanks for your interest! Below you find instructions to help you contribute to this snap.

--- a/bin/fetch-models
+++ b/bin/fetch-models
@@ -1,0 +1,263 @@
+#!/bin/bash
+
+set -e
+set -E # ensure ERR trap is inherited by shell functions
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+MODELS="${SNAP_DATA}/models/openvino-models"
+MUSICGEN_TMP="${SNAP_DATA}/tmp/musicgen_tmp"
+MUSICGEN="${MODELS}/musicgen"
+WHISPER_TMP="${SNAP_DATA}/tmp/whisper_tmp"
+WHISPER="${MODELS}"
+SEPARATION_TMP="${SNAP_DATA}/tmp/separation_tmp"
+SEPARATION="${MODELS}"
+SUPPRESSION_TMP="${SNAP_DATA}/tmp/suppression_tmp"
+SUPPRESSION="${MODELS}"
+RESOLUTION_TMP="${SNAP_DATA}/tmp/resolution_tmp"
+RESOLUTION="${MODELS}/audiosr"
+
+usage() {
+  cat<< EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-b]
+
+Manage the installation of OpenVINO™ AI models for Audacity.
+
+This command must be run with sudo as it installs models to ${SNAP_DATA}, where write access
+is only permitted for the root user.
+
+Available options:
+
+-h, --help      Print this help and exit
+-v, --verbose   Print script debug info
+-b, --batch     Install all models in non-interactive mode
+EOF
+  exit
+}
+
+cleanup() {
+  RC=$?
+  rm -rf "${MUSICGEN_TMP}" "${WHISPER_TMP}" "${SEPARATION_TMP}" "${SUPPRESSION_TMP}" "${RESOLUTION_TMP}"
+  if [ "${RC}" -ne 0 ]; then
+    echo "Warning: the script is not exiting normally. You may need to run again. Pass the -v flag to show debug info."
+  fi
+  exit "${RC}"
+}
+
+trap cleanup SIGINT SIGTERM ERR
+
+silent() {
+  if [ "${verbose}" = 'no' ]; then
+    "$@" > /dev/null 2>&1
+  else
+    "$@"
+  fi
+}
+
+musicgen_status() {
+  if [ -d "${MUSICGEN}" ] && \
+     [ "$(find "${MUSICGEN}" -maxdepth 1 -type f | wc -l)" = '12' ] && \
+     [ "$(find "${MUSICGEN}/mono" -maxdepth 1 -type f | wc -l)" = '17' ] && \
+     [ "$(find "${MUSICGEN}/stereo" -maxdepth 1 -type f | wc -l)" = '17' ]; then 
+    echo ' (installed) '
+  fi
+  echo ''
+}
+
+whisper_status() {
+  if [ -d "${WHISPER}" ] && \
+     [ "$(find "${WHISPER}" -name 'ggml*' | wc -l)" = '9' ]; then
+    echo ' (installed) '
+  fi
+  echo ''
+}
+
+separation_status() {
+  if [ -d "${SEPARATION}" ] && \
+     [ "$(find "${SEPARATION}" -name 'htdemucs_v4*' | wc -l)" = '2' ]; then
+    echo ' (installed) '
+  fi
+  echo ''
+}
+
+suppression_status() {
+  if [ -d "${SUPPRESSION}" ] && \
+     [ "$(find "${SUPPRESSION}" -name 'noise-suppression-denseunet-ll-0001*' | wc -l)" = '2' ] && \
+     [ "$(find "${SUPPRESSION}/deepfilternet2" -maxdepth 1 -type f | wc -l)" = '6' ] && \
+     [ "$(find "${SUPPRESSION}/deepfilternet3" -maxdepth 1 -type f | wc -l)" = '6' ]; then 
+    echo ' (installed) '
+  fi
+  echo ''
+}
+
+resolution_status() {
+  if [ -d "${RESOLUTION}" ] && \
+     [ "$(find "${RESOLUTION}" -maxdepth 1 -type f | wc -l)" = '13' ] && \
+     [ "$(find "${RESOLUTION}/basic" -maxdepth 1 -type f | wc -l)" = '2' ] && \
+     [ "$(find "${RESOLUTION}/speech" -maxdepth 1 -type f | wc -l)" = '2' ]; then 
+    echo ' (installed) '
+  fi
+  echo ''
+}
+
+install_musicgen() {
+  echo "
+Downloading Music Generation models from Hugging Face. Please be patient!
+  "
+  silent git clone https://huggingface.co/Intel/musicgen-static-openvino "${MUSICGEN_TMP}"
+  cd "${MUSICGEN_TMP}"
+  silent git checkout b2ad8083f3924ed704814b68c5df9cbbf2ad2aae
+  silent git lfs install
+  silent git lfs pull
+  mkdir -p "${MUSICGEN}"
+  silent unzip -o "${MUSICGEN_TMP}/musicgen_small_enc_dec_tok_openvino_models.zip" -d "${MUSICGEN}"
+  silent unzip -o "${MUSICGEN_TMP}/musicgen_small_mono_openvino_models.zip" -d "${MUSICGEN}"
+  silent unzip -o "${MUSICGEN_TMP}/musicgen_small_stereo_openvino_models.zip" -d "${MUSICGEN}"
+  rm -rf "${MUSICGEN_TMP}"
+  echo "Music Generation models (~2.8GB) successfully installed to ${MUSICGEN}"
+}
+
+install_whisper() {
+  echo "
+Downloading Whisper Transcription models from Hugging Face. Please be patient!
+  "
+  silent git clone https://huggingface.co/Intel/whisper.cpp-openvino-models "${WHISPER_TMP}"
+  cd "${WHISPER_TMP}"
+  silent git lfs install
+  silent git lfs pull
+  mkdir -p "${WHISPER}"
+  silent unzip -o "${WHISPER_TMP}/ggml-base-models.zip" -d "${WHISPER}"
+  silent unzip -o "${WHISPER_TMP}/ggml-small-models.zip" -d "${WHISPER}"
+  silent unzip -o "${WHISPER_TMP}/ggml-small.en-tdrz-models.zip" -d "${WHISPER}"
+  rm -rf "${WHISPER_TMP}"
+  echo "Whisper Transcription models (~1.5GB) successfully installed to ${WHISPER}"
+}
+
+install_separation() {
+  echo "
+Downloading Music Separation models from Hugging Face. Please be patient!
+  "
+  silent git clone https://huggingface.co/Intel/demucs-openvino "${SEPARATION_TMP}"
+  cd "${SEPARATION_TMP}"
+  silent git checkout 97fc578fb57650045d40b00bc84c7d156be77547
+  mkdir -p "${SEPARATION}"
+  cp "${SEPARATION_TMP}/htdemucs_v4."{bin,xml} "${SEPARATION}"
+  rm -rf "${SEPARATION_TMP}"
+  echo "Music Separation models (~99MB) successfully installed to ${SEPARATION}"
+}
+
+install_suppression() {
+  echo "
+Downloading Noise Suppression models from Hugging Face. Please be patient!
+  "
+  silent git clone https://huggingface.co/Intel/deepfilternet-openvino "${SUPPRESSION_TMP}"
+  cd "${SUPPRESSION_TMP}"
+  silent git checkout 995706bda3da69da0825074ba7dbc8a78067e980
+  silent git lfs install
+  silent git lfs pull
+  mkdir -p "${SUPPRESSION}"
+  silent unzip -o "${SUPPRESSION_TMP}/deepfilternet2.zip" -d "${SUPPRESSION}"
+  silent unzip -o "${SUPPRESSION_TMP}/deepfilternet3.zip" -d "${SUPPRESSION}"
+  silent wget -O "${SUPPRESSION}/noise-suppression-denseunet-ll-0001.xml" "https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/noise-suppression-denseunet-ll-0001/FP16/noise-suppression-denseunet-ll-0001.xml"
+  silent wget -O "${SUPPRESSION}/noise-suppression-denseunet-ll-0001.bin" "https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/noise-suppression-denseunet-ll-0001/FP16/noise-suppression-denseunet-ll-0001.bin"
+  rm -rf "${SUPPRESSION_TMP}"
+  echo "Noise Suppression models (~27MB) successfully installed to ${SUPPRESSION}"
+}
+
+install_resolution() {
+  echo "
+Downloading Super Resolution models from Hugging Face. Please be patient!
+  "
+  silent git clone https://huggingface.co/Intel/versatile_audio_super_resolution_openvino "${RESOLUTION_TMP}"
+  cd "${RESOLUTION_TMP}"
+  silent git lfs install
+  silent git lfs pull
+  mkdir -p "${RESOLUTION}"
+  silent unzip -o "${RESOLUTION_TMP}/versatile_audio_sr_base_openvino_models.zip" -d "${RESOLUTION}"
+  silent unzip -o "${RESOLUTION_TMP}/versatile_audio_sr_ddpm_basic_openvino_models.zip" -d "${RESOLUTION}"
+  silent unzip -o "${RESOLUTION_TMP}/versatile_audio_sr_ddpm_speech_openvino_models.zip" -d "${RESOLUTION}"
+  rm -rf "${RESOLUTION_TMP}"
+  echo "Super Resolution models (~2GB) successfully installed to ${RESOLUTION}"
+}
+
+build_model_menu() {
+  model_menu="
+-------------------------------------------------------------------------------------------------
+| Audacity OpenVINO™ plugins support several AI models available for download from Hugging Face |
+-------------------------------------------------------------------------------------------------
+
+1. Music Generation$(musicgen_status)
+2. Whisper Transcription$(whisper_status)
+3. Music Separation$(separation_status)
+4. Noise Suppression$(suppression_status)
+5. Super Resolution$(resolution_status)
+6. Exit
+
+Some models are several GB in size, so be mindful of your available disk space and network speed.
+
+To download and install a model, please select an option from the menu above and hit enter: "
+}
+
+parse_params() {
+  verbose='no' # default behavior is to run commands silently
+  batch_mode='no' # default behavior is interactive mode
+
+  while :; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) verbose='yes' ;;
+    -b | --batch) batch_mode='yes' ;;
+    -?*) echo "Unknown option: $1" && exit 1 ;;
+    *) break ;;
+    esac
+    shift
+  done
+
+  return 0
+}
+
+loop_menu() {
+  while :; do
+    cd "${SCRIPT_DIR}"
+    build_model_menu
+    read -rp "${model_menu}" model_selection
+    case "${model_selection}" in
+      1) install_musicgen ;;
+      2) install_whisper ;;
+      3) install_separation ;;
+      4) install_suppression ;;
+      5) install_resolution ;;
+      6) exit ;;
+      *) echo "
+Unknown option ${model_selection} selected." ;;
+    esac
+  done
+}
+
+parse_params "$@"
+
+if ! grep -qw "GenuineIntel" /proc/cpuinfo; then
+  echo "The OpenVINO™ AI models are only supported on Intel hardware. Exiting."
+  exit 1
+fi
+
+if [ "${SNAP_UID}" -ne 0 ]; then
+  >&2 echo "
+This tool installs models to ${SNAP_DATA}, 
+where write access is only permitted for the root user.
+Please re-run the command with sudo:
+
+sudo $(basename "${BASH_SOURCE[0]}")
+  "
+  exit 1
+fi
+
+if [ "${batch_mode}" = 'yes' ]; then
+  for model in musicgen whisper separation suppression resolution; do
+    cd "${SCRIPT_DIR}"
+    install_"${model}"
+  done
+else
+  loop_menu
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,14 @@ description: |
   * Change the speed or pitch of a recording
   * Apply a wide range of other effects to audio recordings
 
+  This snap also includes OpenVINO™ AI plugins for music separation, noise suppression,
+  music generation and continuation, transcription, and super resolution. These plugins
+  can only be run on Intel hardware (CPU, GPU, and NPU) and a user must be in the render
+  Unix group in order to run on Intel accelerators (GPU and NPU). To ease the installation
+  of the AI models, the snap also includes a model management command that can be run using:
+
+  sudo audacity.fetch-models
+
 website: https://www.audacityteam.org/
 contact: https://github.com/snapcrafters/audacity/issues
 issues: https://github.com/snapcrafters/audacity/issues
@@ -40,6 +48,19 @@ layout:
     bind: $SNAP/usr/share/audacity
   /usr/share/locale:
     bind: $SNAP/usr/share/locale
+  $SNAP/usr/lib/openvino-models:
+    bind: $SNAP_DATA/models/openvino-models
+  /etc/gitconfig:
+    bind-file: $SNAP_DATA/etc/gitconfig
+
+plugs:
+  intel-npu:
+    interface: custom-device
+    custom-device: intel-npu-device
+  npu-libs:
+    interface: content
+    content: npu-libs-2404
+    target: $SNAP/npu-libs
 
 
 apps:
@@ -55,12 +76,25 @@ apps:
       - audio-playback
       - audio-record
       - home
+      - intel-npu
       - jack1
       - network
       - network-bind
+      - npu-libs
       - pulseaudio
       - removable-media
       - unity7
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/local/lib:$SNAP/usr/local/whisper.cpp/lib:$SNAP/usr/local/libtorch/lib:$SNAP/usr/runtime/lib/intel64:$SNAP/npu-libs:$LD_LIBRARY_PATH
+      OCL_ICD_VENDORS: $SNAP/etc/OpenCL/vendors
+
+  fetch-models:
+    command: usr/bin/fetch-models
+    plugs:
+      - network
+    environment:
+      GIT_EXEC_PATH: $SNAP/usr/lib/git-core
+      GIT_TEMPLATE_DIR: $SNAP/usr/share/git-core/templates
 
 parts:
   alsa-mixin:
@@ -74,8 +108,100 @@ parts:
       - libasound2-plugins
       - yad
 
+  openvino-tokenizers-extension:
+    source-type: git
+    source: https://github.com/openvinotoolkit/openvino_tokenizers
+    source-tag: 2024.6.0.0
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX=/usr
+    build-packages:
+      - libtbb-dev
+    build-snaps:
+      - openvino-toolkit-2404/2024/beta
+    build-environment:
+      - OpenVINO_DIR: /snap/openvino-toolkit-2404/current/usr/lib/x86_64-linux-gnu/cmake
+    override-build: |
+      if [ "$CRAFT_ARCH_BUILD_FOR" == "amd64" ]; then
+        craftctl default
+      fi
+
+  libtorch:
+    plugin: nil
+    build-packages:
+      - wget
+      - unzip
+    override-build: |
+      if [ "$CRAFT_ARCH_BUILD_FOR" == "amd64" ]; then
+        wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcpu.zip
+        mkdir -p ${CRAFT_PART_INSTALL}/usr/local
+        unzip libtorch-cxx11-abi-shared-with-deps-2.4.1+cpu.zip -d ${CRAFT_PART_INSTALL}/usr/local
+      fi
+
+  opencl:
+    # Includes all the compute runtime and OpenCL bits needed for Intel GPU support
+    plugin: nil
+    build-packages:
+      - wget
+    override-build: |
+      if [ "$CRAFT_ARCH_BUILD_FOR" == "amd64" ]; then
+        mkdir -p neo
+        cd neo
+        # Install Intel graphics compiler and compute runtime
+        # This is required to enable GPU support for OpenVINO
+        # https://docs.openvino.ai/2024/get-started/configurations/configurations-intel-gpu.html
+        intel_graphics_compiler_version="2.5.6"
+        intel_graphics_compiler_build="18417"
+        compute_runtime_version="24.52.32224.5"
+        wget https://github.com/intel/intel-graphics-compiler/releases/download/v${intel_graphics_compiler_version}/intel-igc-core-2_${intel_graphics_compiler_version}+${intel_graphics_compiler_build}_amd64.deb
+        wget https://github.com/intel/intel-graphics-compiler/releases/download/v${intel_graphics_compiler_version}/intel-igc-opencl-2_${intel_graphics_compiler_version}+${intel_graphics_compiler_build}_amd64.deb
+        wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/intel-level-zero-gpu_1.6.32224.5_amd64.deb
+        wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/intel-opencl-icd_${compute_runtime_version}_amd64.deb
+        wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/libigdgmm12_22.5.5_amd64.deb
+        dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
+        # update paths to the Intel Installable Client Drivers (ICDs) for OpenCL
+        intel_icd="${CRAFT_PART_INSTALL}"/etc/OpenCL/vendors/intel.icd
+        intel_icd_so_path=$(cat ${intel_icd})
+        base_path="/snap/${SNAPCRAFT_PROJECT_NAME}/current"
+        echo "${base_path}""${intel_icd_so_path}" > "${intel_icd}"
+        intel_legacy1_icd="${CRAFT_PART_INSTALL}"/etc/OpenCL/vendors/intel_legacy1.icd
+        if [ -f ${intel_legacy1_icd} ]; then
+          intel_legacy1_icd_so_path=$(cat ${intel_legacy1_icd})
+          echo "${base_path}""${intel_legacy1_icd_so_path}" > "${intel_legacy1_icd}"
+        fi
+        # fix broken sym links
+        cd "${CRAFT_PART_INSTALL}"
+        ln -sf "${base_path}"/usr/bin/ocloc-24.39.1 etc/alternatives/ocloc
+        ln -sf "${base_path}"/etc/alternatives/ocloc usr/bin/ocloc
+        craftctl default
+      fi
+
+  whisper.cpp:
+    after:
+      - libtorch
+    source-type: git
+    source: https://github.com/ggerganov/whisper.cpp
+    source-tag: v1.5.4
+    plugin: cmake
+    override-build: |
+      if [ "$CRAFT_ARCH_BUILD_FOR" == "amd64" ]; then
+        cmake ${CRAFT_PART_SRC} -DWHISPER_OPENVINO=ON
+        make -j $(nproc)
+        cmake --install . --config Release --prefix ${CRAFT_PART_INSTALL}/usr/local/whisper.cpp
+      fi
+    build-snaps:
+      - openvino-toolkit-2404/2024/beta
+    build-environment:
+      - LIBTORCH_ROOTDIR: $CRAFT_STAGE/usr/local/libtorch
+      - OpenVINO_DIR: /snap/openvino-toolkit-2404/current/usr/lib/x86_64-linux-gnu/cmake
+
   audacity:
-    after: [alsa-mixin]
+    after:
+      - alsa-mixin
+      - openvino-tokenizers-extension
+      - libtorch
+      - whisper.cpp
     plugin: cmake
     source: https://github.com/audacity/audacity.git
     source-tag: Audacity-$SNAPCRAFT_PROJECT_VERSION
@@ -86,6 +212,13 @@ parts:
       sed -i -E 's|Exec=env GDK_BACKEND=x11 UBUNTU_MENUPROXY=0 |Exec=|' src/audacity.desktop.in
       # mod-opus broken with "Error: inappropriate ioctl for device". This disables it.
       sed -i '/mod-opus/d' libraries/lib-module-manager/ModuleSettings.cpp
+      if [ "$CRAFT_ARCH_BUILD_FOR" == "amd64" ]; then
+        sed -i '/mod-opus/d' libraries/lib-module-manager/ModuleSettings.cpp
+        sed -i '/"mod-aup",/a\      "mod-openvino",' libraries/lib-module-manager/ModuleSettings.cpp
+        git clone --depth 1 --branch v3.7.1-R4.2 https://github.com/intel/openvino-plugins-ai-audacity.git
+        cp -r openvino-plugins-ai-audacity/mod-openvino ${CRAFT_PART_SRC}/modules/
+        sed -i '/   sharing/a\    mod-openvino' ${CRAFT_PART_SRC}/modules/CMakeLists.txt
+      fi
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr
       - -DCMAKE_BUILD_TYPE=Release
@@ -105,6 +238,9 @@ parts:
       - PATH: /snap/bin:$PATH
       - CFLAGS: -O2 -pipe
       - CXXFLAGS: -O2 -pipe
+      - LIBTORCH_ROOTDIR: $CRAFT_STAGE/usr/local/libtorch
+      - OpenVINO_DIR: /snap/openvino-toolkit-2404/current/usr/lib/x86_64-linux-gnu/cmake
+      - WHISPERCPP_ROOTDIR: $CRAFT_STAGE/usr/local/whisper.cpp
     build-packages:
       - build-essential
       - cmake
@@ -150,6 +286,7 @@ parts:
       - libwxgtk3.2-dev
       - lv2-dev
       - nasm
+      - ocl-icd-opencl-dev
       - portaudio19-dev
       - python3-pip
       - rapidjson-dev
@@ -159,6 +296,8 @@ parts:
       - wget
       - zlib1g
       - zlib1g-dev
+    build-snaps:
+      - openvino-toolkit-2404/2024/beta
     stage-packages:
       - libavcodec60
       - libavformat60
@@ -207,3 +346,19 @@ parts:
       - libvorbisenc2
       - libwxgtk3.2-1t64
       - zlib1g
+    stage-snaps:
+      - openvino-toolkit-2404/2024/beta
+
+  fetch-models:
+    plugin: dump
+    source: bin/
+    organize:
+      fetch-models: usr/bin/fetch-models
+    # fetch-models exits immediately if not run on Intel hardware,
+    # thus we don't need these packages in the part for arm64
+    stage-packages:
+      - to amd64:
+        - git
+        - git-lfs
+        - unzip
+        - wget


### PR DESCRIPTION
This PR enables five separate AI features in Audacity for users on Intel hardware and replaces https://github.com/snapcrafters/audacity/pull/43 with some key differences in how model management and hardware support are handled.

## Model Management

Current versions of the Audacity plugins do not expose any sort of model management support from the Audacity UI. Instead, users must [manually run a series of commands](https://github.com/intel/openvino-plugins-ai-audacity/tree/main/doc/build_doc/linux#openvino-models-installation) to download and install the models themselves. For now, I've wrapped these steps in a script (`audacity.fetch-models`) to make the process much easier.

However, future versions (likely the next release) of the plugins will expose a UI in Audacity for model management (see discussion with plugin maintainer [here](https://github.com/intel/openvino-plugins-ai-audacity/issues/402)).

The previous PR included the models directly in the snap, but there were [concerns](https://github.com/snapcrafters/audacity/pull/43#discussion_r2045077212) about the size of the snap and the consequences for users on non-Intel hardware.

While snap components would probably be a better overall experience/design than a script, my preference is to keep this initial release simple and not dedicate effort to supporting components since upstream will provide support for model management in the very near future.

## CPU architecture support

This PR keeps everything in a single track rather than proposing a separate track for the AI feature support. I've used CPU architecture checks within the snapcraft parts to only include the AI feature libraries in the snap for `amd64`. This is apparent from the sizes of the two builds: the `amd64` version of the snap is 612 MB, while the `arm64` version is 218 MB.

Additionally, the OpenVINO features are only available in the Audacity UI for `amd64` builds. 

Finally, I included a CPU vendor check in `audacity.fetch-models` so users running on an AMD chip will not be able to install models. They will still see the AI features in the Audacity UI, however they will be unable to load any models because the various drop down menus will be empty. 

## Testing

I've tested on my laptop with an Intel Alder Lake CPU + iGPU and an Intel Core Ultra Meteor Lake equipped with a CPU+iGPU+NPU.