### PR TITLE
chore: install models to SNAP_COMMON, upgrade build-snaps to stable

### DIFF
--- a/bin/fetch-models
+++ b/bin/fetch-models
@@ -6,16 +6,16 @@ set -o pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
-MODELS="${SNAP_DATA}/models/openvino-models"
-MUSICGEN_TMP="${SNAP_DATA}/tmp/musicgen_tmp"
+MODELS="${SNAP_COMMON}/models/openvino-models"
+MUSICGEN_TMP="${SNAP_COMMON}/tmp/musicgen_tmp"
 MUSICGEN="${MODELS}/musicgen"
-WHISPER_TMP="${SNAP_DATA}/tmp/whisper_tmp"
+WHISPER_TMP="${SNAP_COMMON}/tmp/whisper_tmp"
 WHISPER="${MODELS}"
-SEPARATION_TMP="${SNAP_DATA}/tmp/separation_tmp"
+SEPARATION_TMP="${SNAP_COMMON}/tmp/separation_tmp"
 SEPARATION="${MODELS}"
-SUPPRESSION_TMP="${SNAP_DATA}/tmp/suppression_tmp"
+SUPPRESSION_TMP="${SNAP_COMMON}/tmp/suppression_tmp"
 SUPPRESSION="${MODELS}"
-RESOLUTION_TMP="${SNAP_DATA}/tmp/resolution_tmp"
+RESOLUTION_TMP="${SNAP_COMMON}/tmp/resolution_tmp"
 RESOLUTION="${MODELS}/audiosr"
 
 usage() {
@@ -24,7 +24,7 @@ Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-b]
 
 Manage the installation of OpenVINO™ AI models for Audacity.
 
-This command must be run with sudo as it installs models to ${SNAP_DATA}, where write access
+This command must be run with sudo as it installs models to ${SNAP_COMMON}, where write access
 is only permitted for the root user.
 
 Available options:
@@ -171,6 +171,7 @@ Downloading Super Resolution models from Hugging Face. Please be patient!
   "
   silent git clone https://huggingface.co/Intel/versatile_audio_super_resolution_openvino "${RESOLUTION_TMP}"
   cd "${RESOLUTION_TMP}"
+  silent git checkout 9a97d7f128b22aea72e92862a3eccc310f88ac26
   silent git lfs install
   silent git lfs pull
   mkdir -p "${RESOLUTION}"
@@ -244,7 +245,7 @@ fi
 
 if [ "${SNAP_UID}" -ne 0 ]; then
   >&2 echo "
-This tool installs models to ${SNAP_DATA}, 
+This tool installs models to ${SNAP_COMMON},
 where write access is only permitted for the root user.
 Please re-run the command with sudo:
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,7 +54,7 @@ layout:
   /usr/share/locale:
     bind: $SNAP/usr/share/locale
   $SNAP/usr/lib/openvino-models:
-    bind: $SNAP_DATA/models/openvino-models
+    bind: $SNAP_COMMON/models/openvino-models
   /etc/gitconfig:
     bind-file: $SNAP_DATA/etc/gitconfig
 
@@ -129,7 +129,7 @@ parts:
     build-packages:
       - libtbb-dev
     build-snaps:
-      - openvino-toolkit-2404/2024/beta
+      - openvino-toolkit-2404/2024/stable
     build-environment:
       - OpenVINO_DIR: /snap/openvino-toolkit-2404/current/usr/lib/x86_64-linux-gnu/cmake
     override-build: |
@@ -201,7 +201,7 @@ parts:
         cmake --install . --config Release --prefix ${CRAFT_PART_INSTALL}/usr/local/whisper.cpp
       fi
     build-snaps:
-      - openvino-toolkit-2404/2024/beta
+      - openvino-toolkit-2404/2024/stable
     build-environment:
       - LIBTORCH_ROOTDIR: $CRAFT_STAGE/usr/local/libtorch
       - OpenVINO_DIR: /snap/openvino-toolkit-2404/current/usr/lib/x86_64-linux-gnu/cmake
@@ -307,7 +307,7 @@ parts:
       - zlib1g
       - zlib1g-dev
     build-snaps:
-      - openvino-toolkit-2404/2024/beta
+      - openvino-toolkit-2404/2024/stable
     stage-packages:
       - libavcodec60
       - libavformat60
@@ -357,7 +357,7 @@ parts:
       - libwxgtk3.2-1t64
       - zlib1g
     stage-snaps:
-      - openvino-toolkit-2404/2024/beta
+      - openvino-toolkit-2404/2024/stable
 
   fetch-models:
     plugin: dump


### PR DESCRIPTION
This makes the following changes:
* Change the model installation path from SNAP_DATA to SNAP_COMMON. @lucyllewy made this suggestion and I agree it's a better approach as the models are not expected to change between revisions and this avoids copying 6GB+ of data for each new revision.
* Update `openvino-toolkit-2404` in `build-snaps` and `stage-snaps` to use the `stable` risk level (where it was only recently promoted for the first time)
* Check out super resolution models from fixed commit hash based on [feedback from plugin developers](https://github.com/intel/openvino-plugins-ai-audacity/issues/402#issuecomment-2936130487)