### PR TITLE
Add standard lib path back to LD_LIBRARY_PATH

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,7 +94,7 @@ apps:
       - removable-media
       - unity7
     environment:
-      LD_LIBRARY_PATH: $SNAP/usr/local/lib:$SNAP/usr/local/whisper.cpp/lib:$SNAP/usr/local/libtorch/lib:$SNAP/usr/runtime/lib/intel64:$SNAP/npu-libs:$SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      LD_LIBRARY_PATH: $SNAP/usr/local/lib:$SNAP/usr/local/whisper.cpp/lib:$SNAP/usr/local/libtorch/lib:$SNAP/usr/runtime/lib/intel64:$SNAP/npu-libs:$SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
       OCL_ICD_VENDORS: $SNAP/etc/OpenCL/vendors
       PATH: $SNAP/ffmpeg-platform/usr/bin:$PATH
 


### PR DESCRIPTION
This directory was inadvertently removed from the snap's library search path in a [recent PR](https://github.com/snapcrafters/audacity/pull/58) as snapcraft/snapd seem to only preserve the directory in LD_LIBRARY_PATH if a user appends/prepends to the existing LD_LIBRARY_PATH in apps.foobar.environment.

See [this forum post](https://forum.snapcraft.io/t/using-expansion-syntax-in-apps-ld-library-path/47423) for more details.