### PR TITLE
add strip for small lib*.so

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -146,6 +146,8 @@ parts:
         wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-2.4.1%2Bcpu.zip
         mkdir -p ${CRAFT_PART_INSTALL}/usr/local
         unzip libtorch-cxx11-abi-shared-with-deps-2.4.1+cpu.zip -d ${CRAFT_PART_INSTALL}/usr/local
+        strip --strip-unneeded ${CRAFT_PART_INSTALL}/usr/local/libtorch/lib/libtorch_cpu.so
+        strip --strip-unneeded ${CRAFT_PART_INSTALL}/usr/local/libtorch/lib/libtorch_python.so
       fi
 
   opencl:


### PR DESCRIPTION
This option remove debug code for libs .so Issues #78 

### normal 
```
-rwxr-xr-x 1 root root 473M Aug 27  2024 libtorch_cpu.so
-rwxr-xr-x 1 root root  26M Aug 27  2024 libtorch_python.so
```

### strip-unneeded 
```
-rw-r--r-- 1 rsvzz rsvzz 608M Apr 20 11:22 audacity_3.7.7_amd64.snap  
-rwxr-xr-x 1 root root 389M Apr 20 11:37 libtorch_cpu.so
-rwxr-xr-x 1 root root  19M Apr 20 11:37 libtorch_python.so
```