### PR TITLE
ci: schedule daily upstream version sync

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -1,6 +1,9 @@
 name: Update
 
 on:
+  # Runs at 10:00 UTC every day
+  schedule:
+    - cron:  '0 10 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -19,5 +22,11 @@ jobs:
         with:
           token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           update-script: |
-            VERSION=$(curl -s "https://api.github.com/repos/audacity/audacity/releases/latest" | jq -r .tag_name | tr -d 'Audacity-')
+            VERSION=$(
+              curl -sL "https://api.github.com/repos/audacity/audacity/releases" |
+              jq -r '.[] | select(.prerelease == false and .draft == false) | .tag_name' |
+              grep -v beta |
+              head -n 1 |
+              sed 's/^Audacity-//'
+            )
             sed -i 's/^\(version: \).*$/\1'"$VERSION"'/' snap/snapcraft.yaml


### PR DESCRIPTION
## Summary
- run the Update workflow daily at 10:00 UTC, matching the Signal Desktop and Discord Snapcrafters pattern
- keep the update script simple while selecting only non-draft, non-prerelease Audacity releases
- explicitly avoid beta tags before updating `snap/snapcraft.yaml`

## Validation
- `git diff --check`
- extracted `update-script` and ran `bash -n`
- current Audacity releases include `Audacity-4.0.0-beta-2` as a prerelease; the script selects `3.7.8`
- ran the extracted `update-script` against a temporary copy of `snap/snapcraft.yaml`; it resolved `version: 3.7.8`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/sync-version-with-upstream.yml`

@jnsgruk for review.
